### PR TITLE
fix: address zizmor security findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     # Only update Wormhole and Squads dependencies
     allow:
       - dependency-name: "@wormhole-foundation/*"

--- a/.github/workflows/sdk-type-check.yml
+++ b/.github/workflows/sdk-type-check.yml
@@ -14,5 +14,4 @@ permissions:
 
 jobs:
   typecheck-latest:
-    uses: wormhole-foundation/workflows/.github/workflows/wormhole-demo-typecheck.yml@main
-    secrets: inherit
+    uses: wormhole-foundation/workflows/.github/workflows/wormhole-demo-typecheck.yml@3d6ccc988ec1949b31751a30845151b979987246 # main


### PR DESCRIPTION
## Summary

Address zizmor security findings in workflow files.

## Fixes

- **dependabot-cooldown** in `.github/dependabot.yml`: added `cooldown: { default-days: 7 }` to the npm ecosystem entry.
- **unpinned-uses** in `.github/workflows/sdk-type-check.yml`: pinned `wormhole-foundation/workflows/.github/workflows/wormhole-demo-typecheck.yml` from `@main` to commit SHA `3d6ccc988ec1949b31751a30845151b979987246` with a `# main` comment.
- **secrets-inherit** in `.github/workflows/sdk-type-check.yml`: removed `secrets: inherit` — the called reusable workflow does not declare any `secrets:`, so no secrets are needed.